### PR TITLE
Fix errors when no tag associated

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -113,6 +113,8 @@ function plugin_tag_giveItem($type, $field, $data, $num, $linkfield = "") {
 
             list($name, $id) = explode(Search::SHORTSEP, $tag);
             
+            if ($name === Search::NULLVALUE) return;
+            
             $plugintagtag->getFromDB($id);
             $color = $plugintagtag->fields["color"];
             if (! empty($color)) {


### PR DESCRIPTION
In a list of items, if no tag is selected, a PHP error occurs :
PHP Notice: Undefined index: color in /var/www/html/00-GLPI/glpi_090/plugins/tag/hook.php at line 118

Moreover, a list is display with a block with the value "\__NULL__".

see #6