### PR TITLE
fix(core): don't check non isset key

### DIFF
--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -416,6 +416,8 @@ class PluginTagTag extends CommonDropdown {
                'id'       => $item->getId(),
                'value'    => $value,
             ]);
+            echo "<input type='hidden' name='_plugin_tag_tag_process'>";
+
             echo "</td>";
             echo "</tr>";
          }

--- a/inc/tagitem.class.php
+++ b/inc/tagitem.class.php
@@ -328,7 +328,7 @@ class PluginTagTagItem extends CommonDBRelation {
    static function updateItem(CommonDBTM $item, $options = []) {
 
       if ($item->getID()
-          && !isset($item->input["_plugin_tag_tag_values"])) {
+          && !isset($item->input["_plugin_tag_tag_process"])) {
          return true;
       }
 


### PR DESCRIPTION
close #58 

The plugin check if the key exists in the input table, however, if we delete the TAG, the key does not exist in the input table.

Moreover this behavior is managed later in the code, if the key does not exist one creates an empty array