### PR TITLE
Remove usless massive action on subitem

### DIFF
--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -20,6 +20,9 @@ class PluginTagTag extends CommonDropdown {
    public static function getBlacklistItemtype() {
       return [
          'PluginTagTag',
+         'PluginTagTagItem',
+         'Itil_Project',
+         'Item_Project',
          'Notification',
          'Crontask',
          'PluginFormcreatorFormanswer',

--- a/inc/tagitem.class.php
+++ b/inc/tagitem.class.php
@@ -118,7 +118,12 @@ class PluginTagTagItem extends CommonDBRelation {
       echo "<div class='spaced'>";
       if ($canedit && $number) {
          Html::openMassiveActionsForm('mass'.__CLASS__.$rand);
-         Html::showMassiveActions();
+
+         $massiveactionparams['specific_actions']
+               = [ 'MassiveAction:purge'
+                =>  _x('button', 'Delete permanently the relation with selected elements')];
+
+         Html::showMassiveActions($massiveactionparams);
       }
       echo "<table class='tab_cadre_fixe'>";
       echo "<tr>";


### PR DESCRIPTION
When ITIL Object manage sub itemetyp like Project -> Ticket / Project -> Computer
tag display option to add or remove tag but not tag are displayed because itemtype is 'Itil_Project' or 'Item_Project' which are not understand by plugin.

Thoose class used to create lionk between project and other itemtype.

On TagItem class remove 'update' action form massive action see https://github.com/pluginsGLPI/tag/issues/78

this PR prenvet this
