### PR TITLE
Refactor tickets search engine

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -52,11 +52,10 @@ function plugin_tag_getAddSearchOptionsNew($itemtype) {
          'table'         => PluginTagTag::getTable(),
          'field'         => 'name',
          'name'          => PluginTagTag::getTypeName(2),
-         'datatype'      => 'string',
-         'searchtype'    => 'contains',
+         'datatype'      => 'dropdown',
+         'searchtype'    => ['equals','notequals','contains'],
          'massiveaction' => false,
          'forcegroupby'  => true,
-         'usehaving'     => true,
          'joinparams'    =>  [
             'beforejoin' => [
                'table'      => 'glpi_plugin_tag_tagitems',


### PR DESCRIPTION
Signed-off-by: Stanislas <skita@teclib.com>

Use 'dropdown' datatype rather than 'string'
Use 'equals, notequals, contains' searchtype rather than 'contains'

Best regards