### PR TITLE
fix(core): load plugin if needed

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -86,6 +86,10 @@ function plugin_init_tag() {
 
       // Plugin uninstall : after uninstall action
       if ($plugin->isInstalled("uninstall") && $plugin->isActivated("uninstall")) {
+         //to prevent null global variable load plugin if needed
+         if ($UNINSTALL_TYPES == null) {
+            Plugin::load('uninstall');
+         }
          foreach ($UNINSTALL_TYPES as $u_itemtype) {
             $PLUGIN_HOOKS['plugin_uninstall_after']['tag'][$u_itemtype] = 'plugin_uninstall_after_tag';
          }


### PR DESCRIPTION
Signed-off-by: Stanislas <skita@teclib.com>

This warning is display when uninstall plugin is installed and activated,

```
PHP Warning(2): Invalid argument supplied for foreach()
Backtrace :
plugins/tag/setup.php:90
inc/plugin.class.php:168 plugin_init_tag()
inc/includes.php:104 Plugin::load()
front/cron.php:38 include()
```
because uninstall is load after tag, and global variable is not initialize.

to prevent this, uninstall is load if it installed and activated.

see #81 and #77 
