### PR TITLE
GLPI 9.5 compatibility

### DIFF
--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -137,7 +137,7 @@ class PluginTagTag extends CommonDropdown {
 
       // Version 0.90-1.1
       // Disable cache on field list as cache wes not pruned after adding field
-      $fields = $DB->list_fields($table, false);
+      $fields = $DB->listFields($table, false);
       if (stristr($fields['type_menu']["Type"], 'varchar') !== false) {
          $migration->changeField($table, 'type_menu', 'type_menu', 'text');
          $migration->dropKey($table, 'type_menu');

--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -143,7 +143,7 @@ class PluginTagTag extends CommonDropdown {
          $migration->dropKey($table, 'type_menu');
          $migration->migrationOneTable($table);
 
-         $datas = getAllDatasFromTable($table, ['NOT' => ['type_menu' => null]]);
+         $datas = getAllDataFromTable($table, ['NOT' => ['type_menu' => null]]);
          if (!empty($datas)) {
             foreach ($datas as $data) {
                $itemtypes = PluginTagTagItem::getItemtypes($data['type_menu']);

--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -743,4 +743,8 @@ class PluginTagTag extends CommonDropdown {
 
       return false;
    }
+
+   static function getIcon() {
+      return "fas fa-tags";
+   }
 }

--- a/js/entity.js
+++ b/js/entity.js
@@ -55,7 +55,7 @@ var setEntityTag = function() {
    entity_element.addClass('tags_already_set');
 
    $.ajax({
-      url: CFG_GLPI.root_doc + '/plugins/tag/ajax/get_entity_tags.php',
+      url: CFG_GLPI.root_doc + '/' + GLPI_PLUGINS_PATH.tag + '/ajax/get_entity_tags.php',
       data: {
          'name': entity_name,
       },

--- a/setup.php
+++ b/setup.php
@@ -29,20 +29,9 @@
 define ('PLUGIN_TAG_VERSION', '2.6.0');
 
 // Minimal GLPI version, inclusive
-define("PLUGIN_TAG_MIN_GLPI", "9.4");
+define("PLUGIN_TAG_MIN_GLPI", "9.5");
 // Maximum GLPI version, exclusive
 define("PLUGIN_TAG_MAX_GLPI", "9.6");
-
-/**
- * Check configuration process
- *
- * @param boolean $verbose Whether to display message on failure. Defaults to false
- *
- * @return boolean
- */
-function plugin_tag_check_config($verbose = false) {
-   return true;
-}
 
 /**
  * Init hooks of the plugin.
@@ -139,7 +128,7 @@ function plugin_version_tag() {
       'version'        => PLUGIN_TAG_VERSION,
       'author'         => '<a href="http://www.teclib.com">Teclib\'</a> - Infotel conseil',
       'homepage'       => 'https://github.com/pluginsGLPI/tag',
-      'license'        => '<a href="../plugins/tag/LICENSE" target="_blank">GPLv2+</a>',
+      'license'        => '<a href="'.Plugin::getWebDir('tag').'/LICENSE" target="_blank">GPLv2+</a>',
       'requirements'   => [
          'glpi' => [
             'min' => PLUGIN_TAG_MIN_GLPI,
@@ -150,34 +139,6 @@ function plugin_version_tag() {
    ];
 }
 
-/**
- * Check pre-requisites before install
- * OPTIONNAL, but recommanded
- *
- * @return boolean
- */
-function plugin_tag_check_prerequisites() {
-
-   //Version check is not done by core in GLPI < 9.2 but has to be delegated to core in GLPI >= 9.2.
-   if (!method_exists('Plugin', 'checkGlpiVersion')) {
-      $version = preg_replace('/^((\d+\.?)+).*$/', '$1', GLPI_VERSION);
-      $matchMinGlpiReq = version_compare($version, PLUGIN_TAG_MIN_GLPI, '>=');
-      $matchMaxGlpiReq = version_compare($version, PLUGIN_TAG_MAX_GLPI, '<');
-
-      if (!$matchMinGlpiReq || !$matchMaxGlpiReq) {
-         echo vsprintf(
-            'This plugin requires GLPI >= %1$s and < %2$s.',
-            [
-               PLUGIN_TAG_MIN_GLPI,
-               PLUGIN_TAG_MAX_GLPI,
-            ]
-         );
-         return false;
-      }
-   }
-
-   return true;
-}
 
 function idealTextColor($hexTripletColor) {
    $nThreshold      = 105;

--- a/setup.php
+++ b/setup.php
@@ -26,7 +26,7 @@
  --------------------------------------------------------------------------
  */
 
-define ('PLUGIN_TAG_VERSION', '2.6.0');
+define ('PLUGIN_TAG_VERSION', '2.7.0-rc1');
 
 // Minimal GLPI version, inclusive
 define("PLUGIN_TAG_MIN_GLPI", "9.5");

--- a/setup.php
+++ b/setup.php
@@ -31,7 +31,7 @@ define ('PLUGIN_TAG_VERSION', '2.6.0');
 // Minimal GLPI version, inclusive
 define("PLUGIN_TAG_MIN_GLPI", "9.4");
 // Maximum GLPI version, exclusive
-define("PLUGIN_TAG_MAX_GLPI", "9.5");
+define("PLUGIN_TAG_MAX_GLPI", "9.6");
 
 /**
  * Check configuration process


### PR DESCRIPTION
This PR should not be merged before GLPI 9.5 final release.

9.5 compatible pre-releases of the plugin will be created from `9.5-dev` branch.