### PR TITLE
Drop spectrum

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -62,11 +62,12 @@ function plugin_init_tag() {
       $CFG_GLPI['plugin_tag_itemtypes'] = [
          __('Assets')         => ['Computer', 'Monitor', 'Software', 'NetworkEquipment',
                                   'Peripheral', 'Printer', 'CartridgeItem', 'ConsumableItem',
-                                  'Phone'],
+                                  'Phone', 'Enclosure', 'PDU', 'PassiveDCEquipment'],
          __('Assistance')     => ['Ticket', 'Problem', 'Change', 'TicketRecurrent',
                                   'TicketTemplate'],
-         __('Management')     => ['Budget', 'Supplier', 'Contact', 'Contract', 'Document'],
-         __('Tools')          => ['Project', 'Reminder', 'RSSFeed', 'KnowbaseItem'],
+         __('Management')     => ['Budget', 'Supplier', 'Contact', 'Contract', 'Document',
+                                  'Line', 'Certificate', 'Appliance', 'Cluster', 'Domain'],
+         __('Tools')          => ['Project', 'Reminder', 'RSSFeed', 'KnowbaseItem', 'ProjectTask'],
          __('Administration') => ['User', 'Group', 'Entity', 'Profile'],
          __('Setup')          => ['SLA', 'SlaLevel', 'Link'],
       ];

--- a/setup.php
+++ b/setup.php
@@ -89,9 +89,6 @@ function plugin_init_tag() {
       // add link on plugin name in Configuration > Plugin
       $PLUGIN_HOOKS['config_page']['tag'] = "front/tag.php";
 
-      // require spectrum (for glpi >= 9.2)
-      $CFG_GLPI['javascript']['config']['commondropdown']['PluginTagTag'] = ['colorpicker'];
-
       // Plugin use specific massive actions
       $PLUGIN_HOOKS['use_massive_action']['tag'] = true;
 

--- a/setup.php
+++ b/setup.php
@@ -76,6 +76,11 @@ function plugin_init_tag() {
          $CFG_GLPI['plugin_tag_itemtypes'][__('Assets')][] = 'PluginAppliancesAppliance';
       }
 
+      // Plugin Webapplication
+      if ($plugin->isInstalled('webapplications') && $plugin->isActivated('webapplications')) {
+         $CFG_GLPI['plugin_tag_itemtypes'][__('Assets')][] = 'PluginWebapplicationsWebapplication';
+      }
+
       // Plugin fusioninventory
       if ($plugin->isInstalled('fusioninventory') && $plugin->isActivated('fusioninventory')) {
          $CFG_GLPI['plugin_tag_itemtypes'][__('FusionInventory')][] = 'PluginFusioninventoryTask';


### PR DESCRIPTION
GLPI 9.5 dropped Spectrum and the default color picker in modern browsers works fine for this plugin.
Note that IE 11 does not have a color picker and would not work with other parts of GLPI anyways.