### PR TITLE
Remove unnecessary tag purges

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml
+# Editor-based HTTP Client requests
+/httpRequests/

--- a/.idea/deployment.xml
+++ b/.idea/deployment.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PublishConfigData" remoteFilesAllowedToDisappearOnAutoupload="false">
+    <serverData>
+      <paths name="pik.glpi">
+        <serverdata>
+          <mappings>
+            <mapping local="$PROJECT_DIR$" web="/" />
+          </mappings>
+        </serverdata>
+      </paths>
+    </serverData>
+  </component>
+</project>

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ProjectModuleManager">
+    <modules>
+      <module fileurl="file://$PROJECT_DIR$/.idea/tag.iml" filepath="$PROJECT_DIR$/.idea/tag.iml" />
+    </modules>
+  </component>
+</project>

--- a/.idea/php.xml
+++ b/.idea/php.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PhpProjectSharedConfiguration" php_language_level="7.2" />
+</project>

--- a/.idea/tag.iml
+++ b/.idea/tag.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="WEB_MODULE" version="4">
+  <component name="NewModuleRootManager">
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/spec" isTestSource="true" />
+      <sourceFolder url="file://$MODULE_DIR$/tests" isTestSource="true" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/inc/tagitem.class.php
+++ b/inc/tagitem.class.php
@@ -369,13 +369,14 @@ class PluginTagTagItem extends CommonDBRelation {
             'itemtype' => $item->getType()
          ]);
       }
-      foreach ($tag_del as $tag_id) {
-         $tag_item->deleteByCriteria([
-            'plugin_tag_tags_id' => $tag_id,
-            "items_id" => $item->getID(),
-            "itemtype" => $item->getType(),
-         ]);
-      }
+      if (!isset($options['delete_old']) || $options['delete_old'])
+         foreach ($tag_del as $tag_id) {
+            $tag_item->deleteByCriteria([
+               'plugin_tag_tags_id' => $tag_id,
+               "items_id" => $item->getID(),
+               "itemtype" => $item->getType(),
+            ]);
+         }
 
       return true;
    }


### PR DESCRIPTION
Each time when new tag added to the items all existed tags deleted and then restored with new ones. Same with deletion - all tags removed and then restore only those which must stay.