### PR TITLE
fix(core): exclude PluginFormcreatorIssue itemetype

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -177,7 +177,7 @@ function plugin_tag_getDropdown() {
  * @return array the massive action list
  */
 function plugin_tag_MassiveActions($itemtype = '') {
-   if (PluginTagTag::canItemtype($itemtype)) {
+   if (PluginTagTag::canItemtype($itemtype) && is_a($itemtype, CommonDBTM::class, true) && $itemtype::canUpdate()) {      
       return [
          'PluginTagTagItem'.MassiveAction::CLASS_ACTION_SEPARATOR.'addTag'
                => __("Add tags", 'tag'),

--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -59,6 +59,7 @@ class PluginTagTag extends CommonDropdown {
          'PluginPrintercountersRecord',
          'ITILSolution',
          'ITILFollowup',
+         'PluginFormcreatorIssue',
       ];
    }
 

--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -59,7 +59,6 @@ class PluginTagTag extends CommonDropdown {
          'PluginPrintercountersRecord',
          'ITILSolution',
          'ITILFollowup',
-         'PluginFormcreatorIssue',
       ];
    }
 


### PR DESCRIPTION
TAG massive action (add) is display from ```FormCreatorIssue```

But dropdown is empty because connected user do not have right to update / create  ```FormCreatorIssue```

This pr resolve this

Internal ref : !23503 