### PR TITLE
Keep tags on form reload

### DIFF
--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -438,7 +438,10 @@ class PluginTagTag extends CommonDropdown {
             $value = '';
             if (isset($item->input['_plugin_tag_tag_values'])) {
                $value = $item->input['_plugin_tag_tag_values'];
+            } elseif (isset($item->input['_saved']['_plugin_tag_tag_values'])) {
+               $value = $item->input['_saved']['_plugin_tag_tag_values'];
             }
+
 
             $field_class = "form-field row col-12 col-sm-6 px-3 mt-2 mb-n2";
             $label_class = "col-form-label col-xxl-5 text-xxl-end";

--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -442,7 +442,6 @@ class PluginTagTag extends CommonDropdown {
                $value = $item->input['_saved']['_plugin_tag_tag_values'];
             }
 
-
             $field_class = "form-field row col-12 col-sm-6 px-3 mt-2 mb-n2";
             $label_class = "col-form-label col-xxl-5 text-xxl-end";
             $input_class = "col-xxl-7 field-container";

--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -594,13 +594,13 @@ class PluginTagTag extends CommonDropdown {
 
       // find values for this items
       $values = [];
-      if (isset($params['id'])) {
+      if (isset($params['id']) && empty($params['value'])) {
          foreach ($tag_item->find(['items_id' => $params['id'],
                                    'itemtype' => $itemtype]) as $found_item) {
             $values[] = $found_item['plugin_tag_tags_id'];
          }
       } else {
-         $values = explode(',', $params['value']);
+         $values = $params['value'];
       }
 
       // Restrict tags finding by itemtype and entity


### PR DESCRIPTION
Seems like tag values are cleared on form refresh so user need to enter them again (after category change for example or error)
I am not sure about the explode and $params['value'] when they are separated by ",". What I checked it was always passed as an array.