### PR TITLE
Fix Tags on items with similar class names

### DIFF
--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -609,7 +609,7 @@ class PluginTagTag extends CommonDropdown {
             ['type_menu' => null],
             ['type_menu' => ''],
             ['type_menu' => 0],
-            ['type_menu' => ['LIKE', '%'.$itemtype.'%']],
+            ['type_menu' => ['LIKE', '%"'.$itemtype.'"%']],
          ]
       ];
       if ($obj->isEntityAssign()) {


### PR DESCRIPTION
Fix escaping of class name in search of items. It can happen that you can have tags defined for "TicketRecurrent" and they will be shown also for the "Ticket".
Escape with double quotes. Question is whether it can happen it will be stored in DB also without "" (so not the JSON).
At least I can see in DB it is stored also for single type tags like ["Ticket"] so fix is working for me.