### PR TITLE
fix(core): fix huge page load

### DIFF
--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -790,6 +790,22 @@ class PluginTagTag extends CommonDropdown {
     * @return mixed(string/boolean) false if not itemtype found, the string itemtype if found
     */
    public static function getCurrentItemtype() {
+
+      $exclude_paths = [
+         '/ajax/',
+         '/front/locale.php',
+         '/front/cron.php',
+         '/front/marketplace.php',
+         '/front/config.form.php',
+         '/front/central.php'
+      ];
+
+      foreach ($exclude_paths as $path) {
+         if (strpos($_SERVER['PHP_SELF'], $path) !== false) {
+            return false;
+         }
+      }
+
       $itemtype = '';
       if (
           preg_match('/\/(?:marketplace|plugins)\/genericobject\/front\/object\.form.php/', $_SERVER['PHP_SELF'])


### PR DESCRIPTION
Trying to fix huge page load (from cloud context)
Other URLs can probably be removed

Central page load before
![image](https://user-images.githubusercontent.com/7335054/187158190-db1ab3fc-7113-4afb-b68a-208a0860929c.png)

Central page load after
![image](https://user-images.githubusercontent.com/7335054/187158246-7353551d-9b1f-4427-87c4-e83950cf1c10.png)

Ticket page load before
![image](https://user-images.githubusercontent.com/7335054/187158369-2695388f-c7aa-4b21-a49d-969880730beb.png)

Ticket page load after
![image](https://user-images.githubusercontent.com/7335054/187158427-44bc3ce6-9343-4d38-8e57-1080ec45aa42.png)


