### PR TITLE
Add a hook to allow plugins to blacklist types from tagging 

### DIFF
--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -47,7 +47,8 @@ class PluginTagTag extends CommonDropdown {
     * @return array of string itemtypes
     */
    public static function getBlacklistItemtype() {
-      return [
+      $additionalTypes = Plugin::doHookFunction('tag_get_blacklisted_types', []);
+      return array_merge([
          'PluginTagTag',
          'PluginTagTagItem',
          'Itil_Project',
@@ -59,7 +60,7 @@ class PluginTagTag extends CommonDropdown {
          'PluginPrintercountersRecord',
          'ITILSolution',
          'ITILFollowup',
-      ];
+      ], $additionalTypes);
    }
 
    /**


### PR DESCRIPTION
Formcreator has a class in the hard coded blacklist, and the class name will change within 2023. Some other classes should be added. It is easier for plugin maintenance to let other plugin to manage themselve the blacklist

https://github.com/pluginsGLPI/formcreator/pull/2964