### PR TITLE
Fix undefined array key on some new item forms

### DIFF
--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -591,6 +591,9 @@ class PluginTagTag extends CommonDropdown {
       if (isset($params['id'])) {
          $obj->getFromDB($params['id']);
       }
+       if ($obj->isNewItem()) {
+           $obj->getEmpty();
+       }
 
       // find values for this items
       $values = [];


### PR DESCRIPTION
In some cases like Business Rules for Tickets, an undefined array key notice can be raised when calling `checkEntity` via `canCreateItem`  on a new item that hasn't had its fields initialized with the default/empty values.