### PR TITLE
fix undefined tags in kanban

### DIFF
--- a/js/kanban.js
+++ b/js/kanban.js
@@ -40,7 +40,7 @@ $(document).on('kanban:filter', (e, data) => {
       const card = $(item);
 
       let shown = true;
-      const tags = card.data('tags');
+      const tags = card.data('tags') ?? {};
       //lowercase tags
       const tags_lower = Object.values(tags).map(tag => tag.toLowerCase());
       const tagged = tags_lower.length > 0;


### PR DESCRIPTION
In some cases, there may not be any tag data on Kanban cards and this was disrupting the creation of filters.