### PR TITLE
fix: search by tag

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -58,7 +58,6 @@ function plugin_tag_getAddSearchOptionsNew($itemtype) {
          'searchtype'    => ['equals','notequals','contains'],
          'massiveaction' => false,
          'forcegroupby'  => true,
-         'usehaving'     => true,
          'joinparams'    =>  [
             'beforejoin' => [
                'table'      => 'glpi_plugin_tag_tagitems',


### PR DESCRIPTION
If we search via `is_equals` the result returns too many values.
For example, if we searched for the tag with ID = 1, the result would return all tags containing 1 in the ID, so 1, 10, 11...

Before:
![image](https://user-images.githubusercontent.com/8530352/225005201-81e5bafd-e51c-46d1-9cfe-d6a053f93472.png)

After:
![image](https://user-images.githubusercontent.com/8530352/225005533-775f4779-ec8b-4709-8def-0f800f55bbb5.png)
