### PR TITLE
fix: update right

### DIFF
--- a/inc/tagitem.class.php
+++ b/inc/tagitem.class.php
@@ -387,6 +387,10 @@ class PluginTagTagItem extends CommonDBRelation {
       $tag      = new PluginTagTag();
       $tag_item = new self();
 
+      if (!$tag::canUpdate()) {
+         return true;
+      }
+
       // create new values
       $tag_values = !empty($item->input["_plugin_tag_tag_values"])
          ? $item->input["_plugin_tag_tag_values"]


### PR DESCRIPTION
When a user does not have the right to update tags, if he modifies a ticket with tags already linked, they disappear when the ticket is saved.

ref !27746