### PR TITLE
fix: empty itemtype

### DIFF
--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -70,11 +70,7 @@ class PluginTagTag extends CommonDropdown {
     * @return bool
     */
    public static function canItemtype($itemtype = '') {
-      if (empty($itemtype)) {
-         return false;
-      }
-      return (!class_exists($itemtype)
-              || !in_array($itemtype, self::getBlacklistItemtype()));
+      return !empty($itemtype) && class_exists($itemtype) && !in_array($itemtype, self::getBlacklistItemtype());
    }
 
    public function showForm($ID, $options = []) {

--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -70,6 +70,9 @@ class PluginTagTag extends CommonDropdown {
     * @return bool
     */
    public static function canItemtype($itemtype = '') {
+      if (empty($itemtype)) {
+         return false;
+      }
       return (!class_exists($itemtype)
               || !in_array($itemtype, self::getBlacklistItemtype()));
    }


### PR DESCRIPTION
Fix error message when `itemtype = ''`

```
glpiphplog.CRITICAL:   *** Uncaught Exception Error: Class "" not found in /var/www/html/glpi/marketplace/tag/hook.php at line 73
  Backtrace :
  src/Plugin.php:1852                                plugin_tag_getAddSearchOptionsNew()
  src/Search.php:7992                                Plugin::getAddSearchOptionsNew()
  src/Search.php:7679                                Search::getOptions()
  src/SavedSearch.php:590                            Search::getCleanedOptions()
  src/SavedSearch.php:1238                           SavedSearch->prepareQueryToUse()
  src/SavedSearch.php:830                            SavedSearch->execute()
  src/SavedSearch.php:869                            SavedSearch->getMine()
  ajax/savedsearch.php:87                            SavedSearch->displayMine()
```

