### PR TITLE
Fix missing Webhook class

### DIFF
--- a/setup.php
+++ b/setup.php
@@ -61,8 +61,12 @@ function plugin_init_tag() {
                                   'Line', 'Certificate', 'Appliance', 'Cluster', 'Domain'],
          __('Tools')          => ['Project', 'Reminder', 'RSSFeed', 'KnowbaseItem', 'ProjectTask'],
          __('Administration') => ['User', 'Group', 'Entity', 'Profile'],
-         __('Setup')          => ['SLA', 'SlaLevel', 'Link', 'Webhook'],
+         __('Setup')          => ['SLA', 'SlaLevel', 'Link'],
       ];
+
+      if (class_exists('Webhook')) {
+         $CFG_GLPI['plugin_tag_itemtypes'][__('Setup')][] = 'Webhook';
+      }
 
       if (Plugin::isPluginActive('appliances')) {
          $CFG_GLPI['plugin_tag_itemtypes'][__('Assets')][] = 'PluginAppliancesAppliance';


### PR DESCRIPTION
Webhook class doesn't exist in 10.0 (or 10.1 currently) so an error is thrown on the tag form. This PR only adds it to the itemtype array if the class exists.