### PR TITLE
Fix broken tag rules with ticket created from mails

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -176,7 +176,7 @@ function plugin_tag_getDropdown() {
  * @return array the massive action list
  */
 function plugin_tag_MassiveActions($itemtype = '') {
-   if (PluginTagTag::canItemtype($itemtype) && is_a($itemtype, CommonDBTM::class, true) && $itemtype::canUpdate()) {      
+   if (PluginTagTag::canItemtype($itemtype) && is_a($itemtype, CommonDBTM::class, true) && $itemtype::canUpdate()) {
       return [
          'PluginTagTagItem'.MassiveAction::CLASS_ACTION_SEPARATOR.'addTag'
                => __("Add tags", 'tag'),
@@ -256,6 +256,13 @@ function plugin_tag_post_init() {
          $PLUGIN_HOOKS['pre_item_purge']['tag'][$itemtype]  = ['PluginTagTagItem', 'purgeItem'];
       }
    }
+
+   // Always define hook for tickets
+   // Needed for rules to function properly when a ticket is created from a mail
+   // collector
+   $PLUGIN_HOOKS['item_add']['tag'][Ticket::getType()]        = ['PluginTagTagItem', 'updateItem'];
+   $PLUGIN_HOOKS['pre_item_update']['tag'][Ticket::getType()] = ['PluginTagTagItem', 'updateItem'];
+   $PLUGIN_HOOKS['pre_item_purge']['tag'][Ticket::getType()]  = ['PluginTagTagItem', 'purgeItem'];
 }
 
 function plugin_tag_getRuleActions($params = [])

--- a/inc/tagitem.class.php
+++ b/inc/tagitem.class.php
@@ -379,7 +379,15 @@ class PluginTagTagItem extends CommonDBRelation {
    static function updateItem(CommonDBTM $item, bool $delete_existing_tags = true) {
 
       if ($item->getID()
-          && !isset($item->input["_plugin_tag_tag_process_form"])) {
+         && !isset($item->input["_plugin_tag_tag_process_form"])
+         && !(
+            // Always trigger on newly created tickets, as they may come from
+            // the mail collector which wont set the _plugin_tag_tag_process_form
+            // flag
+            $item::getType() == Ticket::getType()
+            && $item->fields['date_creation'] == $_SESSION['glpi_currenttime']
+         )
+      ) {
          return true;
       }
 


### PR DESCRIPTION
Tag may be added through the "Add tags" rule action, however this wont work for ticket coming from GLPI's mail receivers due to the way the plugin declare its hooks.

Fixed by forcing the hook on ticket to always be active.