### PR TITLE
fix searching for multiple tags

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -58,6 +58,7 @@ function plugin_tag_getAddSearchOptionsNew($itemtype) {
          'searchtype'    => ['equals','notequals','contains'],
          'massiveaction' => false,
          'forcegroupby'  => true,
+         'usehaving'     => true,
          'joinparams'    =>  [
             'beforejoin' => [
                'table'      => 'glpi_plugin_tag_tagitems',


### PR DESCRIPTION
When searching for tickets with a tag, the result only displayed the tag corresponding to the search, but not the other tags in the ticket.

Before:
![image](https://github.com/pluginsGLPI/tag/assets/8530352/71b6caa8-b446-423f-b62d-dc02aa6cfd5f)

After:
![image](https://github.com/pluginsGLPI/tag/assets/8530352/84fba6e4-708b-4ac5-a1e7-8d0a1d8611d3)
