### PR TITLE
Fix tag display on entities with parenthesis in their names

### DIFF
--- a/js/entity.js
+++ b/js/entity.js
@@ -56,11 +56,7 @@ var setEntityTag = function() {
                 },
                 success: function(response) {
                     entity_element.html(function() {
-                        if ($(this).html().indexOf(')') > 0) {
-                            return $(this).html().replace(/\)$/, response + ')');
-                        } else {
-                            return $(this).html() + response;
-                        }
+                        return $(this).html() + response;
                     });
                 }
             });


### PR DESCRIPTION
Tag are not displayed on entities with parenthesis in their names:

![image](https://github.com/pluginsGLPI/tag/assets/42734840/d2ae9a87-ff89-48e3-9945-1ee75ceda9d1)

There is some weird condition looking for a `)`, not sure whats its doing since there is no comment in the code but it works as expected once it's removed:

![image](https://github.com/pluginsGLPI/tag/assets/42734840/406c3668-ac3e-46d1-ab92-135a469611a8)
