### PR TITLE
Fix tag from cron

### DIFF
--- a/inc/tagitem.class.php
+++ b/inc/tagitem.class.php
@@ -420,7 +420,7 @@ SQL;
         $tag_item = new self();
 
         // Be careful to not check right if the change is coming from the cron
-        if (!isCommandLine() && !$tag::canUpdate()) {
+        if (!Session::isCron() && !$tag::canUpdate()) {
             return true;
         }
 

--- a/inc/tagitem.class.php
+++ b/inc/tagitem.class.php
@@ -419,7 +419,8 @@ SQL;
         $tag      = new PluginTagTag();
         $tag_item = new self();
 
-        if (!$tag::canUpdate()) {
+        // Be careful to not check right if the change is coming from the cron
+        if (!isCommandLine() && !$tag::canUpdate()) {
             return true;
         }
 


### PR DESCRIPTION
Fix !30667

Tag may be added by automatic actions (mailgate -> ticket creation -> ticket rule -> add tag action), in this case we must not check the session rights as there is no real user logged in.