### PR TITLE
fix: Unknown column 'is_active'

### DIFF
--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -149,10 +149,12 @@ SQL;
         } else {
             if (!$DB->fieldExists($table, 'type_menu')) {
                 $migration->addField($table, 'type_menu', "text");
+                $migration->migrationOneTable($table);
             }
 
             if (!$DB->fieldExists($table, 'is_active')) {
                 $migration->addField($table, 'is_active', "tinyint NOT NULL DEFAULT '1'");
+                $migration->migrationOneTable($table);
             }
 
             $migration->addKey($table, 'name');


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] This change requires a documentation update.

## Description

- It fixes #206 
- Here is a brief description of what this PR does

Fix this error message:
`SQL Error "1054": Unknown column 'is_active' in 'where clause' in query "SELECT * FROM glpi_plugin_tag_tags WHERE is_active = '1' AND ((type_menu IS NULL) OR (type_menu = '') OR (type_menu = '0') OR (type_menu LIKE '%"PluginMfaConfig"%')) ORDER BY name"`

