### PR TITLE
See Tag Only On Active Itemtypes

### DIFF
--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -85,7 +85,10 @@ class PluginTagTag extends CommonDropdown
                 $use_global_tag = true;
             }
         }
-        return !empty($itemtype) && class_exists($itemtype) && !in_array($itemtype, self::getBlacklistItemtype()) && ($use_global_tag == true ? $use_global_tag : in_array($itemtype, $types_menu));
+        return !empty($itemtype) &&
+            class_exists($itemtype) &&
+            !in_array($itemtype, self::getBlacklistItemtype()) &&
+            ($use_global_tag || in_array($itemtype, $types_menu));
     }
 
     public function showForm($ID, $options = [])

--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -78,7 +78,7 @@ class PluginTagTag extends CommonDropdown
         $tags = new self();
         $types_menu = [];
         foreach ($tags->find(['is_active' => 1]) as $tag) {
-            $types_menu = array_merge($types_menu ,json_decode($tag['type_menu']));
+            $types_menu = array_merge($types_menu, json_decode($tag['type_menu']));
         }
         return !empty($itemtype) && class_exists($itemtype) && !in_array($itemtype, self::getBlacklistItemtype()) && in_array($itemtype, $types_menu);
     }

--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -75,20 +75,23 @@ class PluginTagTag extends CommonDropdown
      */
     public static function canItemtype($itemtype = '')
     {
+        if (empty($itemtype) || !class_exists($itemtype) || in_array($itemtype, self::getBlacklistItemtype())) {
+            return false;
+        }
+
         $tags = new self();
         $types_menu = [];
         $use_global_tag = false;
+
         foreach ($tags->find(['is_active' => 1]) as $tag) {
-            if ($tag['type_menu'] != null) {
+            if (!empty($tag['type_menu'])) {
                 $types_menu = array_merge($types_menu, json_decode($tag['type_menu']));
             } else {
                 $use_global_tag = true;
             }
         }
-        return !empty($itemtype) &&
-            class_exists($itemtype) &&
-            !in_array($itemtype, self::getBlacklistItemtype()) &&
-            ($use_global_tag || in_array($itemtype, $types_menu));
+
+        return $use_global_tag || in_array($itemtype, $types_menu);
     }
 
     public function showForm($ID, $options = [])

--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -77,10 +77,15 @@ class PluginTagTag extends CommonDropdown
     {
         $tags = new self();
         $types_menu = [];
+        $use_global_tag = false;
         foreach ($tags->find(['is_active' => 1]) as $tag) {
-            $types_menu = array_merge($types_menu, json_decode($tag['type_menu']));
+            if ($tag['type_menu'] != null) {
+                $types_menu = array_merge($types_menu, json_decode($tag['type_menu']));
+            } else {
+                $use_global_tag = true;
+            }
         }
-        return !empty($itemtype) && class_exists($itemtype) && !in_array($itemtype, self::getBlacklistItemtype()) && in_array($itemtype, $types_menu);
+        return !empty($itemtype) && class_exists($itemtype) && !in_array($itemtype, self::getBlacklistItemtype()) && ($use_global_tag == true ? $use_global_tag : in_array($itemtype, $types_menu));
     }
 
     public function showForm($ID, $options = [])

--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -75,7 +75,12 @@ class PluginTagTag extends CommonDropdown
      */
     public static function canItemtype($itemtype = '')
     {
-        return !empty($itemtype) && class_exists($itemtype) && !in_array($itemtype, self::getBlacklistItemtype());
+        $tags = new self();
+        $types_menu = [];
+        foreach ($tags->find(['is_active' => 1]) as $tag) {
+            $types_menu = array_merge($types_menu ,json_decode($tag['type_menu']));
+        }
+        return !empty($itemtype) && class_exists($itemtype) && !in_array($itemtype, self::getBlacklistItemtype()) && in_array($itemtype, $types_menu);
     }
 
     public function showForm($ID, $options = [])


### PR DESCRIPTION
- [X ] I have performed a self-review of my code.
- [X ] I have added tests (when available) that prove my fix is effective or that my feature works.


## Description

By design you will see Tag dropdown on all objects, but in fact you nee to display the dropdown only on itemtypes with active tag

