### PR TITLE
Search Options: fix negative tag research

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -52,27 +52,34 @@ function plugin_tag_getAddSearchOptionsNew($itemtype)
         return [];
     }
 
-    $options = [
-        [
-            'id'            => PluginTagTag::S_OPTION,
-            'table'         => PluginTagTag::getTable(),
-            'field'         => 'name',
-            'name'          => PluginTagTag::getTypeName(2),
-            'datatype'      => 'dropdown',
-            'searchtype'    => ['equals','notequals','contains'],
-            'massiveaction' => false,
-            'forcegroupby'  => true,
-            'use_subquery'  => true,
-            'joinparams'    =>  [
-                'beforejoin' => [
-                    'table'      => 'glpi_plugin_tag_tagitems',
-                    'joinparams' => [
-                        'jointype' => 'itemtype_item',
-                    ],
+    $glpiVersion = new Plugin();
+    $glpiVersion = $glpiVersion->getGlpiVersion();
+
+    $so_param = [
+        'id'            => PluginTagTag::S_OPTION,
+        'table'         => PluginTagTag::getTable(),
+        'field'         => 'name',
+        'name'          => PluginTagTag::getTypeName(2),
+        'datatype'      => 'dropdown',
+        'searchtype'    => ['equals','notequals','contains'],
+        'massiveaction' => false,
+        'forcegroupby'  => true,
+        'joinparams'    =>  [
+            'beforejoin' => [
+                'table'      => 'glpi_plugin_tag_tagitems',
+                'joinparams' => [
+                    'jointype' => 'itemtype_item',
                 ],
-            ],
-        ],
+            ]
+        ]
     ];
+
+    if (version_compare($glpiVersion, "10.0.19", '>=')) {
+        $so_param['use_subquery'] = true;
+        $so_param['joinparams']['beforejoin']['joinparams']['field'] = 'items_id';
+    }
+
+    $options[] = $so_param;
 
     if ($itemtype != 'AllAssets') {
         $item = new $itemtype();

--- a/hook.php
+++ b/hook.php
@@ -70,8 +70,8 @@ function plugin_tag_getAddSearchOptionsNew($itemtype)
                 'joinparams' => [
                     'jointype' => 'itemtype_item',
                 ],
-            ]
-        ]
+            ],
+        ],
     ];
 
     if (version_compare($glpiVersion, "10.0.19", '>=')) {

--- a/hook.php
+++ b/hook.php
@@ -62,6 +62,7 @@ function plugin_tag_getAddSearchOptionsNew($itemtype)
             'searchtype'    => ['equals','notequals','contains'],
             'massiveaction' => false,
             'forcegroupby'  => true,
+            'use_subquery'  => true,
             'joinparams'    =>  [
                 'beforejoin' => [
                     'table'      => 'glpi_plugin_tag_tagitems',


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

If we search for an item that does not contain a specific tag, the "is not" search will not work. For example, if a ticket has a tag "Tag1" and "Tag2", and we perform this search:

![Capture d’écran du 2025-02-13 16-46-22](https://github.com/user-attachments/assets/0eb1691d-5576-45d1-a8d6-a4232da32bdf)

the ticket is still returned

To work, it also needs this PR in the core: https://github.com/glpi-project/glpi/pull/18978
