### PR TITLE
Fix the addition of multiple tags via rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [UNRELEASED]
 
+### Fixed
+
+- Fix the addition of multiple tags via rules
+
 ## [2.12.2] - 2025-02-19
 
 ### Fixed

--- a/hook.php
+++ b/hook.php
@@ -288,6 +288,11 @@ function plugin_tag_getRuleActions($params = [])
                 'name'  => __("Add tags", 'tag'),
                 'type'  => 'dropdown',
                 'table' => PluginTagTag::getTable(),
+                'force_actions' => [
+                    0 => "assign",
+                    1 => "append"
+                ],
+                'appendto' => '_additional_tags_from_rules',
                 'condition' => ['type_menu' => ['LIKE', '%\"Ticket\"%']],
             ];
 

--- a/hook.php
+++ b/hook.php
@@ -265,7 +265,7 @@ function plugin_tag_post_init()
     if ($itemtype = PluginTagTag::getCurrentItemtype()) {
         if (PluginTagTag::canItemtype($itemtype)) {
             $PLUGIN_HOOKS['item_add']['tag'][$itemtype]        = ['PluginTagTagItem', 'updateItem'];
-            $PLUGIN_HOOKS['pre_item_update']['tag'][$itemtype] = ['PluginTagTagItem', 'updateItem'];
+            $PLUGIN_HOOKS['item_update']['tag'][$itemtype] = ['PluginTagTagItem', 'updateItem'];
             $PLUGIN_HOOKS['pre_item_purge']['tag'][$itemtype]  = ['PluginTagTagItem', 'purgeItem'];
         }
     }
@@ -274,7 +274,7 @@ function plugin_tag_post_init()
     // Needed for rules to function properly when a ticket is created from a mail
     // collector
     $PLUGIN_HOOKS['item_add']['tag'][Ticket::getType()]        = ['PluginTagTagItem', 'updateItem'];
-    $PLUGIN_HOOKS['pre_item_update']['tag'][Ticket::getType()] = ['PluginTagTagItem', 'updateItem'];
+    $PLUGIN_HOOKS['item_update']['tag'][Ticket::getType()]  = ['PluginTagTagItem', 'updateItem'];
     $PLUGIN_HOOKS['pre_item_purge']['tag'][Ticket::getType()]  = ['PluginTagTagItem', 'purgeItem'];
 }
 

--- a/hook.php
+++ b/hook.php
@@ -288,10 +288,7 @@ function plugin_tag_getRuleActions($params = [])
                 'name'  => __("Add tags", 'tag'),
                 'type'  => 'dropdown',
                 'table' => PluginTagTag::getTable(),
-                'force_actions' => [
-                    0 => "assign",
-                    1 => "append"
-                ],
+                'force_actions' => ['assign', 'append'],
                 'appendto' => '_additional_tags_from_rules',
                 'condition' => ['type_menu' => ['LIKE', '%\"Ticket\"%']],
             ];

--- a/inc/tagitem.class.php
+++ b/inc/tagitem.class.php
@@ -446,6 +446,7 @@ SQL;
             !Session::isCron()
             && !$tag::canUpdate()
             && !isset($item->input["_plugin_tag_tag_from_rules"])
+            && !isset($item->input["_additional_tags_from_rules"])
         ) {
             return true;
         }

--- a/inc/tagitem.class.php
+++ b/inc/tagitem.class.php
@@ -457,7 +457,10 @@ SQL;
         $tag_from_rules = !empty($item->input["_plugin_tag_tag_from_rules"])
          ? [$item->input["_plugin_tag_tag_from_rules"]]
          : [];
-        $tag_values = array_merge($tag_values, $tag_from_rules);
+         $additional_tags_from_rules = !empty($item->input["_additional_tags_from_rules"])
+         ? $item->input["_additional_tags_from_rules"]
+         : [];
+        $tag_values = array_merge($tag_values, $tag_from_rules, $additional_tags_from_rules);
         if (!is_array($tag_values)) {
             // Business rule engine will add value as a unique string that must be converted to array.
             $tag_values = [$tag_values];

--- a/tests/units/TagRuleTest.php
+++ b/tests/units/TagRuleTest.php
@@ -34,6 +34,7 @@ use GlpiPlugin\Tag\Tests\TagTestCase;
 use PluginTagTag;
 use PluginTagTagItem;
 use Profile;
+use Profile_User;
 use Ticket;
 use User;
 
@@ -113,11 +114,157 @@ final class TagRuleTest extends TagTestCase
         $this->isTicketTagged($ticket, $tagID2);
     }
 
+    public function testAssignTagOnTicketCreation(): void
+    {
+        $user_id = $this->loginAs(self::TECH_USER);
+
+        $tagID1 = $this->createTag('TicketTag1');
+        $tagID2 = $this->createTag('TicketTag2');
+
+        $this->createRule($tagID1, 'name', 'Add Tag', 'assign', \RuleTicket::ONADD);
+
+        $ticket = $this->createTicket([
+            'name' => 'Ticket add Tag',
+            'content' => 'Test Content',
+            '_users_id_assign' => $user_id,
+            '_plugin_tag_tag_values' => [$tagID2]
+        ]);
+
+        $this->isTicketTagged($ticket, $tagID1);
+
+        $this->isTicketTagged($ticket, $tagID2);
+    }
+
+    public function testAppendTagOnTicketCreation(): void
+    {
+        $user_id = $this->loginAs(self::TECH_USER);
+
+        $tagID1 = $this->createTag('TicketTag1');
+        $tagID2 = $this->createTag('TicketTag2');
+
+        $this->createRule($tagID1, 'name', 'Add Tag', 'append', \RuleTicket::ONADD);
+
+        $ticket = $this->createTicket([
+            'name' => 'Ticket add Tag',
+            'content' => 'Test Content',
+            '_users_id_assign' => $user_id,
+            '_plugin_tag_tag_values' => [$tagID2]
+        ]);
+
+        $this->isTicketTagged($ticket, $tagID1);
+        $this->isTicketTagged($ticket, $tagID2);
+    }
+
+    public function testAssignOverridesPreviousTags(): void
+    {
+        $user_id = $this->loginAs(self::TECH_USER);
+
+        $tagID1 = $this->createTag('TicketTag1');
+        $tagID2 = $this->createTag('TicketTag2');
+        $tagID3 = $this->createTag('TicketTag3');
+
+        $ticket = $this->createTicket([
+            'name' => 'Ticket Test',
+            'content' => 'Initial content',
+            '_users_id_assign' => $user_id,
+            '_plugin_tag_tag_values' => [$tagID2]
+        ]);
+
+        $this->isTicketTagged($ticket, $tagID2);
+
+        $this->createRule($tagID1, 'content', 'Updated content', 'assign', \RuleTicket::ONUPDATE);
+
+        $this->updateTicket($ticket->getID(), [
+            'content' => 'Updated content',
+            '_plugin_tag_tag_values' => [$tagID3]
+        ]);
+
+        $this->isTicketTagged($ticket, $tagID1);
+        $this->isTicketNotTagged($ticket, $tagID2);
+        $this->isTicketTagged($ticket, $tagID3);
+    }
+
+    public function testAppendPreservesPreviousTags(): void
+    {
+        $user_id = $this->loginAs(self::TECH_USER);
+
+        $tagID1 = $this->createTag('TicketTag1');
+        $tagID2 = $this->createTag('TicketTag2');
+        $tagID3 = $this->createTag('TicketTag3');
+
+        $ticket = $this->createTicket([
+            'name' => 'Ticket Test',
+            'content' => 'Initial content',
+            '_users_id_assign' => $user_id,
+            '_plugin_tag_tag_values' => [$tagID2]
+        ]);
+
+        $this->isTicketTagged($ticket, $tagID2);
+
+        $this->createRule($tagID1, 'content', 'Updated content', 'append', \RuleTicket::ONUPDATE);
+
+        $this->updateTicket($ticket->getID(), [
+            'content' => 'Updated content',
+            '_plugin_tag_tag_values' => [$tagID2, $tagID3]
+        ]);
+
+        $this->isTicketTagged($ticket, $tagID1);
+        $this->isTicketTagged($ticket, $tagID2);
+        $this->isTicketTagged($ticket, $tagID3);
+    }
+
+    public function testMultipleRulesWithDifferentActions(): void
+    {
+        $user_id = $this->loginAs(self::TECH_USER);
+
+        $tagID1 = $this->createTag('RuleTag1');
+        $tagID2 = $this->createTag('RuleTag2');
+        $tagID3 = $this->createTag('ManualTag');
+
+        $this->createRule($tagID1, 'name', 'Multiple Rules', 'assign', \RuleTicket::ONADD);
+
+        $this->createRule($tagID2, 'content', 'Updated for multiple rules', 'append', \RuleTicket::ONUPDATE);
+
+        $ticket = $this->createTicket([
+            'name' => 'Multiple Rules Test',
+            'content' => 'Initial content',
+            '_users_id_assign' => $user_id,
+            '_plugin_tag_tag_values' => [$tagID3]
+        ]);
+
+        $this->isTicketTagged($ticket, $tagID1);
+        $this->isTicketTagged($ticket, $tagID3);
+
+        $this->updateTicket($ticket->getID(), [
+            'content' => 'Updated for multiple rules',
+            '_plugin_tag_tag_values' => [$tagID1, $tagID3]
+        ]);
+
+        $this->isTicketTagged($ticket, $tagID1);
+        $this->isTicketTagged($ticket, $tagID2);
+        $this->isTicketTagged($ticket, $tagID3);
+    }
+
     private function loginAs(array $credentials): int
     {
+        global $DB;
+
         $login = $credentials['login'];
         $pass  = $credentials['pass'];
         $user  = getItemByTypeName('User', $login);
+        $user_profile = Profile_User::getUserProfiles($user->getID());
+        $user_profile = array_keys($user_profile)[0];
+
+        $DB->update(
+            'glpi_profilerights',
+            [
+                'rights' => CREATE | UPDATE | PURGE
+            ],
+            [
+                'profiles_id' => $user_profile,
+                'name'        => PluginTagTag::$rightname,
+            ]
+        );
 
         $this->login($login, $pass);
 
@@ -145,7 +292,8 @@ final class TagRuleTest extends TagTestCase
         int $tagID,
         string $criteria_field = 'name',
         string $criteria_pattern = 'Add Tag',
-        string $action_type = 'assign'
+        string $action_type = 'assign',
+        int $condition = \RuleTicket::ONADD
     ): void {
         $rule       = new \Rule();
         $criteria   = new \RuleCriteria();
@@ -157,7 +305,7 @@ final class TagRuleTest extends TagTestCase
             'entities_id' => 0,
             'sub_type'    => 'RuleTicket',
             'match'       => \Rule::AND_MATCHING,
-            'condition'   => 1,
+            'condition'   => $condition,
             'description' => ''
         ]);
         $this->assertGreaterThan(0, (int)$rules_id);
@@ -202,5 +350,23 @@ final class TagRuleTest extends TagTestCase
         $ticketTag = $tagItem->getFromDBForItems(PluginTagTag::getById($tagID), $ticket);
 
         $this->assertTrue($ticketTag);
+    }
+
+    private function updateTicket(int $ticket_id, array $data): void
+    {
+        $ticket = new Ticket();
+        $ticket->getFromDB($ticket_id);
+        $data['id'] = $ticket_id;
+        $this->assertTrue($ticket->update($data));
+
+        $ticket->getFromDB($ticket_id);
+    }
+
+    private function isTicketNotTagged(Ticket $ticket, int $tagID): void
+    {
+        $tagItem = new PluginTagTagItem();
+        $ticketTag = $tagItem->getFromDBForItems(PluginTagTag::getById($tagID), $ticket);
+
+        $this->assertFalse($ticketTag);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !36508
- Here is a brief description of what this PR does

Adding multiple tags via business rules doesn't work. If, for example, two rules each adding a tag are triggered when a ticket is created, only one tag is added.
This PR therefore adds the `Add` option to the `Add tag` action in the rules.

This PR corrects the problem if this patch is present: https://github.com/glpi-project/glpi/pull/19058

## Screenshots (if appropriate):

![image](https://github.com/user-attachments/assets/00ad14ec-2a68-4892-b7c5-ac33940f532c)
