### PR TITLE
Fix -  Add tag from a rule when updating actors only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+- Fix the addition of tag from a rule when updating actors only
 - Fix the addition of multiple tags via rules
 
 ## [2.12.2] - 2025-02-19

--- a/hook.php
+++ b/hook.php
@@ -282,14 +282,20 @@ function plugin_tag_post_init()
 
 function plugin_tag_rule_matched($params = [])
 {
-    if ($params['sub_type'] == \RuleTicket::class) {
-        if (!empty($params['output'])) {
-            if (isset($params['output']['id'])) {
-                $ticket = new Ticket();
-                $ticket->getFromDB($params['output']['id']);
-                $ticket->input = $params['output'];
-                PluginTagTagItem::updateItem($ticket);
-            }
+    // Ensure tags are added when only actors are updated, as actor updates are processed in post_add
+    if (
+        $params['sub_type'] == \RuleTicket::class
+        && !empty($params['output'])
+        && isset($params['output']['id'])
+        && (
+            isset($params['output']["_plugin_tag_tag_from_rules"])
+            || isset($params['output']["_additional_tags_from_rules"])
+        )
+    ) {
+        $ticket = new Ticket();
+        if ($ticket->getFromDB($params['output']['id'])) {
+            $ticket->input = array_merge($ticket->input, $params['output']);
+            PluginTagTagItem::updateItem($ticket);
         }
     }
 }

--- a/hook.php
+++ b/hook.php
@@ -265,7 +265,7 @@ function plugin_tag_post_init()
     if ($itemtype = PluginTagTag::getCurrentItemtype()) {
         if (PluginTagTag::canItemtype($itemtype)) {
             $PLUGIN_HOOKS['item_add']['tag'][$itemtype]        = ['PluginTagTagItem', 'updateItem'];
-            $PLUGIN_HOOKS['item_update']['tag'][$itemtype] = ['PluginTagTagItem', 'updateItem'];
+            $PLUGIN_HOOKS['item_update']['tag'][$itemtype]     = ['PluginTagTagItem', 'updateItem'];
             $PLUGIN_HOOKS['pre_item_purge']['tag'][$itemtype]  = ['PluginTagTagItem', 'purgeItem'];
         }
     }
@@ -274,8 +274,24 @@ function plugin_tag_post_init()
     // Needed for rules to function properly when a ticket is created from a mail
     // collector
     $PLUGIN_HOOKS['item_add']['tag'][Ticket::getType()]        = ['PluginTagTagItem', 'updateItem'];
-    $PLUGIN_HOOKS['item_update']['tag'][Ticket::getType()]  = ['PluginTagTagItem', 'updateItem'];
+    $PLUGIN_HOOKS['item_update']['tag'][Ticket::getType()]     = ['PluginTagTagItem', 'updateItem'];
     $PLUGIN_HOOKS['pre_item_purge']['tag'][Ticket::getType()]  = ['PluginTagTagItem', 'purgeItem'];
+
+    $PLUGIN_HOOKS['rule_matched']['tag'] = 'plugin_tag_rule_matched';
+}
+
+function plugin_tag_rule_matched($params = [])
+{
+    if ($params['sub_type'] == \RuleTicket::class) {
+        if (!empty($params['output'])) {
+            if (isset($params['output']['id'])) {
+                $ticket = new Ticket();
+                $ticket->getFromDB($params['output']['id']);
+                $ticket->input = $params['output'];
+                PluginTagTagItem::updateItem($ticket);
+            }
+        }
+    }
 }
 
 function plugin_tag_getRuleActions($params = [])


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [x] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !36334
- Here is a brief description of what this PR does

If we create the following rule : 
**Criteria** : _Requester in group_ | _is_ | _Group 1_
**Actions** : _Add tags_ | _Assign_ | _Test Tag_

With in `Group 1`, the user named `User2`

We create a ticket with `User1` as requester.
Update the ticket, changing only the requester to `User2`.
The rule is supposed to be played and the tag added.
However, modifying only the actors doesn't take you through the ticket update process, you're stopped at the `pre_item_update` stage, as the rest must be managed by `TicketUser` or equivalent.
As a result, the code that adds the tag is not reached and, consequently, the tag is not added as it should be.

The solution is to switch to the tag addition code as soon as a rule is checked.
