### PR TITLE
Fix: Prevents FormCreator from deleting tags added via rules

### DIFF
--- a/inc/tagitem.class.php
+++ b/inc/tagitem.class.php
@@ -447,6 +447,15 @@ SQL;
             return true;
         }
 
+        if (
+            empty($item->input["_plugin_tag_tag_values"])
+            && empty($item->input["_plugin_tag_tag_from_rules"])
+            && empty($item->input["_additional_tags_from_rules"])
+            && empty($item->input["_plugin_tag_tag_process_form"])
+        ) {
+            return true;
+        }
+
         // create new values
         $tag_values = !empty($item->input["_plugin_tag_tag_values"])
          ? $item->input["_plugin_tag_tag_values"]


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !38112

When a tag was added via rules when the ticket was created and the ticket was generated via FormCreator, the tag was immediately deleted (visible in the ticket history).

![image](https://github.com/user-attachments/assets/ddee73d0-0ac5-48e1-a6ce-e2fdc2c721ae)

_In FormCreator, in the target settings: `Ticket tags = None`_
