### PR TITLE
Fix: tag not added by rules

### DIFF
--- a/inc/tagitem.class.php
+++ b/inc/tagitem.class.php
@@ -426,7 +426,8 @@ SQL;
                 // the mail collector which wont set the _plugin_tag_tag_process_form
                 // flag
                 $item::getType() == Ticket::getType()
-                && $item->fields['date_creation'] == $_SESSION['glpi_currenttime']
+                // Allow a few seconds difference if glpi_currenttime changed
+                && abs(strtotime($item->fields['date_creation']) - strtotime($_SESSION['glpi_currenttime'])) < 5
             )
         ) {
             return true;


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !36827

Adding tags via rules when creating a ticket did not work if users in another time zone were notified during creation, because in this case, `$_SESSION[‘glpi_currenttime’]` is updated, which creates a difference of a few seconds with the value of `$item->fields[‘date_creation’]`.

