### PR TITLE
fix(form): fix tag dropdown display and save functionality

### DIFF
--- a/hook.php
+++ b/hook.php
@@ -317,6 +317,13 @@ function plugin_tag_post_init()
     $PLUGIN_HOOKS[Hooks::PRE_ITEM_UPDATE]['tag'][Ticket::getType()]     = ['PluginTagTagItem', 'updateItem'];
     $PLUGIN_HOOKS[Hooks::PRE_ITEM_PURGE]['tag'][Ticket::getType()]  = ['PluginTagTagItem', 'purgeItem'];
 
+    // Always define hook for Form (GLPI 11 namespace class)
+    // Needed because getCurrentItemtype() doesn't handle namespaces correctly
+    $PLUGIN_HOOKS[Hooks::ITEM_ADD]['tag']['Glpi\\Form\\Form']        = ['PluginTagTagItem', 'updateItem'];
+    $PLUGIN_HOOKS[Hooks::ITEM_UPDATE]['tag']['Glpi\\Form\\Form']     = ['PluginTagTagItem', 'updateItem'];
+    $PLUGIN_HOOKS[Hooks::PRE_ITEM_UPDATE]['tag']['Glpi\\Form\\Form']     = ['PluginTagTagItem', 'updateItem'];
+    $PLUGIN_HOOKS[Hooks::PRE_ITEM_PURGE]['tag']['Glpi\\Form\\Form']  = ['PluginTagTagItem', 'purgeItem'];
+
     $PLUGIN_HOOKS['rule_matched']['tag'] = 'plugin_tag_rule_matched';
 }
 

--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -648,13 +648,16 @@ SQL;
             $values = $params['value'];
         }
 
+        /** @var DBmysql $DB */
+        global $DB;
+
         $where = [
             'is_active' => 1,
             'OR' => [
                 ['type_menu' => null],
                 ['type_menu' => ''],
                 ['type_menu' => 0],
-                ['type_menu' => ['LIKE', '%"' . $itemtype . '"%']],
+                new \Glpi\DBAL\QueryExpression("JSON_CONTAINS(type_menu, " . $DB->quote('"' . addslashes($itemtype) . '"') . ")"),
             ],
         ];
         if ($obj->isEntityAssign()) {
@@ -665,8 +668,6 @@ SQL;
         foreach ($available_tags as $tag_data) {
             $available_tags[$tag_data['id']] = $tag_data['name'];
             $available_tags_color[$tag_data['id']] = $tag_data['color'] ?: '#DDDDDD';
-            // 'selected' => in_array($tag_data['id'], $values),
-            // 'color'    => $tag_data['color'] ?: '#DDDDDD',
         }
 
         $selected_tags = [];
@@ -720,6 +721,7 @@ SQL;
             'icon'              => Computer::getIcon(),
             'items_id'          => $params['id'],
             'in_itilobject'     => $obj instanceof CommonITILObject,
+            'is_form'           => $obj instanceof \Glpi\Form\Form,
             'is_new_item'       => $obj->isNewItem(),
             'tag_search_url'    => self::getSearchURL(),
         ]);

--- a/setup.php
+++ b/setup.php
@@ -71,7 +71,7 @@ function plugin_init_tag()
                 'Line', 'Certificate', 'Appliance', 'Cluster', 'Domain',
             ],
             __('Tools')          => ['Project', 'Reminder', 'RSSFeed', 'KnowbaseItem', 'ProjectTask'],
-            __('Administration') => ['User', 'Group', 'Entity', 'Profile'],
+            __('Administration') => ['User', 'Group', 'Entity', 'Profile', 'Glpi\\Form\\Form'],
             __('Setup')          => ['SLA', 'SlaLevel', 'Link'],
         ];
 

--- a/templates/tag_dropdown.html.twig
+++ b/templates/tag_dropdown.html.twig
@@ -29,10 +29,13 @@
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
 {% if not in_itilobject %}
-    <div class="hr-text mt-2">
-        <i class="fa-2x ti ti-tag"></i>
-        <span>{{ __('Tags', 'tag') }}</span>
-    </div>
+
+    {% if not is_form %}
+        <div class="hr-text mt-2">
+            <i class="fa-2x ti ti-tag"></i>
+            <span>{{ __('Tags', 'tag') }}</span>
+        </div>
+    {% endif %}
 
     {# For non itil object (new or not) we need to adapt class and boostrap layout #}
     {% set class = is_new_item ? 'col-xxl-12' : 'col-xxl-9' %}
@@ -61,6 +64,40 @@
 
 {% set tooltip = tooltip_parts | join(' ') %}
 
+{% set tagDropdownOptions = {
+    'in_itilobject': {
+        'full_width': true,
+        'field_class': 'col-12 col-sm-12',
+        'label_class': 'col-2 col-sm-2',
+        'input_class': 'col-10 col-sm-10' ~ (can_create ? ' btn-group btn-group-sm' : ''),
+        'is_horizontal': true,
+        'align_label_right': true
+    },
+    'is_form': {
+        'full_width': true,
+        'field_class': 'col-12 col-sm-12',
+        'label_class': 'form-label',
+        'input_class': 'w-100' ~ (can_create ? ' btn-group btn-group-sm' : ''),
+        'is_horizontal': false,
+        'align_label_right': false
+    },
+    'default': {
+        'full_width': false,
+        'field_class': 'col-12 col-sm-6 mb-2',
+        'label_class': 'col-xxl-5 text-xxl-end',
+        'input_class': 'col-xxl-7' ~ (can_create ? ' btn-group btn-group-sm' : ''),
+        'is_horizontal': true,
+        'align_label_right': true
+    }
+} %}
+
+{% if in_itilobject %}
+    {% set currentOptions = tagDropdownOptions.in_itilobject %}
+{% elseif is_form is defined and is_form %}
+    {% set currentOptions = tagDropdownOptions.is_form %}
+{% else %}
+    {% set currentOptions = tagDropdownOptions.default %}
+{% endif %}
 
 {{ fields.dropdownArrayField(
     '_plugin_tag_tag_values',
@@ -74,11 +111,12 @@
         class: 'tag_select',
         disabled: readOnly,
         multiple: true,
-        full_width: in_itilobject ? true : false,
+        full_width: currentOptions.full_width,
         add_field_html : tooltip|raw,
-        field_class: in_itilobject ? 'col-12 col-sm-12' : 'col-12 col-sm-6  mb-2',
-        label_class: in_itilobject ? 'col-2 col-sm-2' : 'col-xxl-5 text-xxl-end',
-        input_class: (in_itilobject ? 'col-10 col-sm-10' : 'col-xxl-7') ~ (can_create ? ' btn-group btn-group-sm' : '')
+        field_class: currentOptions.field_class,
+        label_class: currentOptions.label_class,
+        input_class: currentOptions.input_class,
+        align_label_right: currentOptions.align_label_right
     }
 ) }}
 
@@ -170,8 +208,10 @@
             </div>
         </div>
     </div>
-    <div class="hr-text mt-2">
-        <i class="fa-2x {{ icon }}"></i>
-        <span>{{ itemtype|itemtype_name }}</span>
-    </div>
+    {% if not is_form %}
+        <div class="hr-text mt-2">
+            <i class="fa-2x {{ icon }}"></i>
+            <span>{{ itemtype|itemtype_name }}</span>
+        </div>
+    {% endif %}
 {% endif %}


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- When using the Tag plugin with forms, the dropdown added by the plugin is not suitable for display. In addition, some features provided by the plugin do not work correctly in forms.

## Screenshots (if appropriate):

Before:
<img width="1665" height="521" alt="image" src="https://github.com/user-attachments/assets/892adfee-24cd-472b-b425-f1d7ff2b4afd" />

After:
<img width="1665" height="521" alt="image" src="https://github.com/user-attachments/assets/84040bfd-e99d-46f9-865e-050137693085" />

