### PR TITLE
Fix tag deletion before escalation

### DIFF
--- a/inc/tagitem.class.php
+++ b/inc/tagitem.class.php
@@ -488,7 +488,9 @@ SQL;
             'plugin_tag_tags_id',
         );
         $added_tags_ids   = array_diff($tag_values, $existing_tags_ids);
-        $removed_tags_ids = $delete_existing_tags ? array_diff($existing_tags_ids, $tag_values) : [];
+        // Only remove existing tags if we actually have tag values to process AND delete_existing_tags is true
+        // This prevents removing tags when updating an item without explicitly managing tags
+        $removed_tags_ids = ($delete_existing_tags && !empty($tag_values)) ? array_diff($existing_tags_ids, $tag_values) : [];
 
         // link tags with the current item
         foreach ($added_tags_ids as $tag_id) {


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes !39553
- Here is a brief description of what this PR does
When escalating via the Escalate button in the plugin, the tags associated with the ticket by the Tag plugin are deleted.

## Screenshots (if appropriate):
