### PR TITLE
Fix: Reduces the loading of get_entity_tags.php

### DIFF
--- a/public/js/entity.js
+++ b/public/js/entity.js
@@ -40,7 +40,7 @@ $(function() {
 });
 
 var setEntityTag = function() {
-    $('.entity-name, .entity-badge, .glpi-badge').each(
+    $('.entity-name, .glpi-badge').each(
         function() {
             var entity_element = $(this);
             var entity_name = entity_element.attr('title');


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [ ] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes #N/A

Avoid calling `get_entity_tags.php` when the name is empty, as this raises a 400 error and increases the loading time of the entire page.

## Screenshots (if appropriate):
