### PR TITLE
fix(forms): Fix quote display in tag destination field strategy labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Fix tag search
-
+- Fix quote display in tag destination field strategy labels
 
 ## [2.14.2] - 2025-12-02
 

--- a/inc/destinationfieldstrategy.class.php
+++ b/inc/destinationfieldstrategy.class.php
@@ -40,10 +40,10 @@ enum PluginTagDestinationFieldStrategy: string
     public function getLabel(): string
     {
         return match ($this) {
-            self::NO_TAGS           => __s("No tags"),
-            self::SPECIFIC_VALUES   => __s("Specific tags"),
-            self::SPECIFIC_ANSWERS  => __s("Answers from specific questions"),
-            self::LAST_VALID_ANSWER => __s('Answer to last "Tag" question'),
+            self::NO_TAGS           => __("No tags"),
+            self::SPECIFIC_VALUES   => __("Specific tags"),
+            self::SPECIFIC_ANSWERS  => __("Answers from specific questions"),
+            self::LAST_VALID_ANSWER => __('Answer to last "Tag" question'),
         };
     }
 


### PR DESCRIPTION
## Checklist before requesting a review

*Please delete options that are not relevant.*

- [X] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [X] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/orgs/glpi-project/projects/7/views/1?pane=issue&itemId=141096534

Fix incorrect quote rendering in tag destination field dropdown options.
Quotes were displayed as &quot; instead of proper quotation marks.