### PR TITLE
fix(uninstall): remove tag rights during uninstall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Prevent SQL error when column `name` not exist from `Item_Device`
 - Prevent the tag field from appearing in the satisfaction survey.
 - Fix display translations
+- Removed tag rights during plugin uninstall
 
 ## [2.14.3] - 2025-12-22
 

--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -238,6 +238,12 @@ SQL;
             ],
         ]);
 
+        $DB->delete(ProfileRight::getTable(), [
+            'OR' => [
+                'name'      => self::$rightname,
+            ],
+        ]);
+
         $migration = new Migration(PLUGIN_TAG_VERSION);
         $migration->dropTable(getTableForItemType(self::class));
 

--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -238,11 +238,8 @@ SQL;
             ],
         ]);
 
-        $DB->delete(ProfileRight::getTable(), [
-            'OR' => [
-                'name'      => self::$rightname,
-            ],
-        ]);
+        $profileRight = new ProfileRight();
+        $profileRight->deleteByCriteria(['name' => self::$rightname]);
 
         $migration = new Migration(PLUGIN_TAG_VERSION);
         $migration->dropTable(getTableForItemType(self::class));


### PR DESCRIPTION
- [x] I have performed a self-review of my code.
- [ ] I have added tests (when available) that prove my fix is effective or that my feature works.
- [x] I have updated the CHANGELOG with a short functional description of the fix or new feature.
- [ ] This change requires a documentation update.

## Description

- It fixes https://github.com/pluginsGLPI/tag/pull/349
- The plugin's permissions were still present in the glpi_profilrights table after uninstallation

## Screenshots (if appropriate):
<img width="1187" height="193" alt="image" src="https://github.com/user-attachments/assets/87cb4d1f-9304-4d28-8a45-c4b72e8f0408" />
