### PR TITLE
2.14.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [UNRELEASED]
+## [2.14.4] - 2026-06-24
 
 ### Fixed
 

--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -544,7 +544,7 @@ SQL;
                 $color = $data['color'] ?: '#DDDDDD';
                 $textcolor = idealTextColor($color);
                 $style = sprintf('background-color: %s; color: %s;', $color, $textcolor);
-                $content .= sprintf("<span class='tag_choice' style='%s' title='%s'>%s</span>&nbsp;&nbsp;", $style, $title, htmlentities($name, ENT_QUOTES, "UTF-8"));
+                $content .= sprintf("<span class='tag_choice' style='%s' title='%s'>%s</span>&nbsp;&nbsp;", $style, $title, htmlentities((string) $name, ENT_QUOTES, "UTF-8"));
             }
 
             $content .= "</div>";

--- a/plugin.xml
+++ b/plugin.xml
@@ -34,6 +34,11 @@
    </authors>
    <versions>
       <version>
+         <num>2.14.4</num>
+         <compatibility>~11.0.1</compatibility>
+         <download_url>https://github.com/pluginsGLPI/tag/releases/download/2.14.4/glpi-tag-2.14.4.tar.bz2</download_url>
+      </version>
+      <version>
          <num>2.14.3</num>
          <compatibility>~11.0.1</compatibility>
          <download_url>https://github.com/pluginsGLPI/tag/releases/download/2.14.3/glpi-tag-2.14.3.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -39,7 +39,7 @@ use GlpiPlugin\Webapplications\Webapplication;
 
 use function Safe\define;
 
-define('PLUGIN_TAG_VERSION', '2.14.3');
+define('PLUGIN_TAG_VERSION', '2.14.4');
 
 // Minimal GLPI version, inclusive
 define("PLUGIN_TAG_MIN_GLPI", "11.0.1");


### PR DESCRIPTION
## [2.14.4] - 2026-06-24

### Fixed

- Fix tag search
- Fix `webapplication` plugin integration
- Prevent SQL error when column `name` not exist from `Item_Device`
- Prevent the tag field from appearing in the satisfaction survey.
- Fix display translations
- Removed tag rights during plugin uninstall
- Fix tag dropdown to allow tag creation directly from the field