### PR TITLE
fix(tag): handle scalar type_menu in massive updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 
 - Harden tag input handling and rendering across a few endpoints and templates
+- Fix massive update of associated item types when GLPI provides a scalar value
 
 ## [2.14.5] - 2026-06-25
 

--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -795,7 +795,13 @@ SQL;
     public function encodeSubtypes($input)
     {
         if (!empty($input['type_menu'])) {
-            $input['type_menu'] = json_encode(array_values($input['type_menu']));
+            $type_menu = $input['type_menu'];
+
+            if (!is_array($type_menu)) {
+                $type_menu = [$type_menu];
+            }
+
+            $input['type_menu'] = json_encode(array_values($type_menu));
         }
 
         return $input;

--- a/tests/Units/TagTest.php
+++ b/tests/Units/TagTest.php
@@ -98,11 +98,15 @@ final class TagTest extends TagTestCase
 
     public function testUpdateAcceptsScalarTypeMenu(): void
     {
-        $tag = $this->createItem(PluginTagTag::class, [
-            'name' => 'Massive update test',
-            'is_active' => 1,
-            'type_menu' => ['Ticket', 'Problem'],
-        ]);
+        $tag = $this->createItem(
+            PluginTagTag::class,
+            [
+                'name' => 'Massive update test',
+                'is_active' => 1,
+                'type_menu' => ['Ticket', 'Problem'],
+            ],
+            ['type_menu'],
+        );
 
         $tag = $this->updateItem(
             PluginTagTag::class,

--- a/tests/Units/TagTest.php
+++ b/tests/Units/TagTest.php
@@ -94,5 +94,26 @@ final class TagTest extends TagTestCase
             sprintf("AND `ITEM_0` LIKE %s", $DB->quote('%' . $val . '%')),
             $having,
         );
+    public function testUpdateAcceptsScalarTypeMenu(): void
+    {
+        $tag = new PluginTagTag();
+
+        $tagId = $tag->add([
+            'name' => 'Massive update test',
+            'is_active' => 1,
+            'type_menu' => ['Ticket', 'Problem'],
+        ]);
+
+        $this->assertGreaterThan(0, $tagId);
+
+        $this->assertTrue(
+            $tag->update([
+                'id' => $tagId,
+                'type_menu' => 'Ticket',
+            ]),
+        );
+
+        $this->assertTrue($tag->getFromDB($tagId));
+        $this->assertSame('["Ticket"]', $tag->fields['type_menu']);
     }
 }

--- a/tests/Units/TagTest.php
+++ b/tests/Units/TagTest.php
@@ -94,26 +94,23 @@ final class TagTest extends TagTestCase
             sprintf("AND `ITEM_0` LIKE %s", $DB->quote('%' . $val . '%')),
             $having,
         );
+    }
+
     public function testUpdateAcceptsScalarTypeMenu(): void
     {
-        $tag = new PluginTagTag();
-
-        $tagId = $tag->add([
+        $tag = $this->createItem(PluginTagTag::class, [
             'name' => 'Massive update test',
             'is_active' => 1,
             'type_menu' => ['Ticket', 'Problem'],
         ]);
 
-        $this->assertGreaterThan(0, $tagId);
-
-        $this->assertTrue(
-            $tag->update([
-                'id' => $tagId,
-                'type_menu' => 'Ticket',
-            ]),
+        $tag = $this->updateItem(
+            PluginTagTag::class,
+            $tag->getID(),
+            ['type_menu' => 'Ticket'],
+            ['type_menu'],
         );
 
-        $this->assertTrue($tag->getFromDB($tagId));
         $this->assertSame('["Ticket"]', $tag->fields['type_menu']);
     }
 }


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective.
- [x] I have updated the CHANGELOG with a short functional description of the fix.
- [ ] This change requires a documentation update.

## Description

- Fixes #359 .
- Prevents a `TypeError` when updating tag associated item types through GLPI massive actions.
- Normalizes scalar `type_menu` values into an array before calling `array_values()` and encoding the value as JSON.
- Preserves the existing behavior when `type_menu` is already an array.
- Adds a regression test covering an update where `type_menu` is provided as a scalar string.

## Testing

- Added `TagTest::testUpdateAcceptsScalarTypeMenu()`.
- Verified PHP syntax for the modified and new files.
- Ran the PHPUnit test suite successfully.


## Screenshots

Not applicable. This is a backend error handling fix.