### PR TITLE
fix(tag): allow multiple item types in massive updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Harden tag input handling and rendering across a few endpoints and templates
 - Fix massive update of associated item types when GLPI provides a scalar value
+- Allow selecting multiple associated item types in massive updates
 
 ## [2.14.5] - 2026-06-25
 

--- a/hook.php
+++ b/hook.php
@@ -386,3 +386,28 @@ function plugin_tag_getRuleActions($params = [])
 
     return $actions;
 }
+
+/**
+ * Display plugin-specific fields for the update massive action.
+ *
+ * @param array $params Massive action field parameters
+ *
+ */
+function plugin_tag_MassiveActionsFieldsDisplay(array $params): bool
+{
+    if (
+        ($params['itemtype'] ?? null) !== PluginTagTag::class
+        || ($params['options']['field'] ?? null) !== 'type_menu'
+    ) {
+        return false;
+    }
+
+    echo PluginTagTag::getSpecificValueToSelect(
+        'type_menu',
+        'type_menu',
+        ['type_menu' => []],
+        ['multiple' => true],
+    );
+
+    return true;
+}

--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -385,17 +385,29 @@ SQL;
         ]];
     }
 
-    public static function getSpecificValueToSelect($field, $name = '', $values = '', array $options = [])
-    {
+    public static function getSpecificValueToSelect(
+        $field,
+        $name = '',
+        $values = '',
+        array $options = [],
+    ) {
         /** @var array $CFG_GLPI */
         global $CFG_GLPI;
+
         if (!is_array($values)) {
             $values = [$field => $values];
         }
 
         if ($field === 'type_menu') {
-            $elements  = ['' => Dropdown::EMPTY_VALUE];
+            $multiple = (bool) ($options['multiple'] ?? false);
+
+            // Do not add an empty option to a multiple dropdown.
+            $elements = $multiple
+                ? []
+                : ['' => Dropdown::EMPTY_VALUE];
+
             $supported_itemtypes = $CFG_GLPI['plugin_tag_itemtypes'] ?? [];
+
             foreach ($supported_itemtypes as $itemtypes) {
                 foreach ($itemtypes as $itemtype) {
                     $item = getItemForItemtype($itemtype);
@@ -403,16 +415,47 @@ SQL;
                 }
             }
 
+            $selected = $values[$field] ?? ($multiple ? [] : '');
+
+            if ($multiple) {
+                if (!is_array($selected)) {
+                    $selected = $selected === ''
+                        ? []
+                        : [$selected];
+                }
+
+                return Dropdown::showFromArray(
+                    $name,
+                    $elements,
+                    [
+                        'display'  => false,
+                        'multiple' => true,
+                        'values'   => array_values($selected),
+                    ],
+                );
+            }
+
+            // Preserve the original single-select behavior.
+            if (is_array($selected)) {
+                $selected = reset($selected) ?: '';
+            }
+
             return Dropdown::showFromArray(
                 $name,
                 $elements,
-                ['display' => false,
-                    'value'   => $values[$field],
+                [
+                    'display' => false,
+                    'value'   => $selected,
                 ],
             );
         }
 
-        return parent::getSpecificValueToSelect($field, $name, $values, $options);
+        return parent::getSpecificValueToSelect(
+            $field,
+            $name,
+            $values,
+            $options,
+        );
     }
 
     public static function getSpecificValueToDisplay($field, $values, array $options = [])

--- a/tests/Units/TagMassiveActionTest.php
+++ b/tests/Units/TagMassiveActionTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/**
+ * -------------------------------------------------------------------------
+ * Tag plugin for GLPI
+ * -------------------------------------------------------------------------
+ *
+ * LICENSE
+ *
+ * This file is part of Tag.
+ *
+ * Tag is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * Tag is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with Tag. If not, see <http://www.gnu.org/licenses/>.
+ * -------------------------------------------------------------------------
+ * @copyright Copyright (C) 2014-2023 by Teclib'.
+ * @license   GPLv2 https://www.gnu.org/licenses/gpl-2.0.html
+ * @link      https://github.com/pluginsGLPI/tag
+ * -------------------------------------------------------------------------
+ */
+
+namespace GlpiPlugin\Tag\Tests\Units;
+
+use GlpiPlugin\Tag\Tests\TagTestCase;
+use PluginTagTag;
+
+use function Safe\ob_get_clean;
+use function Safe\ob_start;
+
+final class TagMassiveActionTest extends TagTestCase
+{
+    public function testAssociatedItemTypesCanUseMultipleDropdown(): void
+    {
+        $html = PluginTagTag::getSpecificValueToSelect(
+            'type_menu',
+            'type_menu',
+            ['type_menu' => []],
+            ['multiple' => true],
+        );
+
+        $this->assertIsString($html);
+        $this->assertStringContainsString('type_menu', $html);
+        $this->assertStringContainsString('multiple', $html);
+    }
+
+    public function testAssociatedItemTypesRemainSingleByDefault(): void
+    {
+        $html = PluginTagTag::getSpecificValueToSelect(
+            'type_menu',
+            'type_menu',
+            ['type_menu' => 'Ticket'],
+        );
+
+        $this->assertIsString($html);
+        $this->assertStringContainsString('type_menu', $html);
+        $this->assertStringNotContainsString('multiple="multiple"', $html);
+    }
+
+    public function testMassiveActionHookHandlesTypeMenu(): void
+    {
+        ob_start();
+
+        $handled = plugin_tag_MassiveActionsFieldsDisplay([
+            'itemtype' => PluginTagTag::class,
+            'options' => [
+                'field' => 'type_menu',
+            ],
+        ]);
+
+        $html = ob_get_clean();
+
+        $this->assertTrue($handled);
+        $this->assertStringContainsString('type_menu', $html);
+        $this->assertStringContainsString('multiple', $html);
+    }
+
+    public function testMassiveActionHookIgnoresOtherFields(): void
+    {
+        ob_start();
+
+        $handled = plugin_tag_MassiveActionsFieldsDisplay([
+            'itemtype' => PluginTagTag::class,
+            'options' => [
+                'field' => 'name',
+            ],
+        ]);
+
+        $html = ob_get_clean();
+
+        $this->assertFalse($handled);
+        $this->assertSame('', $html);
+    }
+}


### PR DESCRIPTION
## Checklist before requesting a review

- [x] I have performed a self-review of my code.
- [x] I have added tests that prove my fix is effective.
- [x] I have updated the CHANGELOG with a short functional description of the fix.
- [ ] This change requires a documentation update.

## Description

- Fixes #361 .
- Allows users to select multiple associated item types when updating tags through massive actions.
- Preserves the existing behavior of replacing the current associated item type list.
- Submits the selected item types as an array.
- Adds a regression test covering multiple selected item types.

This issue is separate from #359 and PR #360. Those changes handle scalar values submitted by the existing single-select field, while this pull request changes the massive action field to support multiple selections.

## Testing

- Verified that multiple associated item types can be selected.
- Verified that all selected values are stored in `type_menu`.
- Verified that the selected values are applied to all tags included in the massive action.
- Ran the PHPUnit test suite successfully.

## Screenshots
<img width="1136" height="297" alt="before" src="https://github.com/user-attachments/assets/4a3126d8-47ac-48f3-b67f-c32af502d0db" />


<img width="1122" height="291" alt="after" src="https://github.com/user-attachments/assets/f1607d71-fb09-440d-a662-9a84eca469b5" />

### Before

The massive action field only accepts one associated item type.

### After

The massive action field accepts multiple associated item types.