### PR TITLE
2.14.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [Unreleased]
+## [2.14.7] - 2026-08-11
 
 ### Fixed
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -34,6 +34,16 @@
    </authors>
    <versions>
       <version>
+         <num>2.14.7</num>
+         <compatibility>~11.0.1</compatibility>
+         <download_url>https://github.com/pluginsGLPI/tag/releases/download/2.14.7/glpi-tag-2.14.7.tar.bz2</download_url>
+      </version>
+      <version>
+         <num>2.12.6</num>
+         <compatibility>~10.0.11</compatibility>
+         <download_url>https://github.com/pluginsGLPI/tag/releases/download/2.12.6/glpi-tag-2.12.6.tar.bz2</download_url>
+      </version>
+      <version>
          <num>2.14.6</num>
          <compatibility>~11.0.1</compatibility>
          <download_url>https://github.com/pluginsGLPI/tag/releases/download/2.14.6/glpi-tag-2.14.6.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -39,7 +39,7 @@ use GlpiPlugin\Webapplications\Webapplication;
 
 use function Safe\define;
 
-define('PLUGIN_TAG_VERSION', '2.14.6');
+define('PLUGIN_TAG_VERSION', '2.14.7');
 
 // Minimal GLPI version, inclusive
 define("PLUGIN_TAG_MIN_GLPI", "11.0.1");

--- a/tests/TagTestCase.php
+++ b/tests/TagTestCase.php
@@ -59,7 +59,7 @@ abstract class TagTestCase extends DbTestCase
         $DB->update(
             'glpi_profilerights',
             [
-                'rights' => CREATE | UPDATE | PURGE,
+                'rights' => READ | CREATE | UPDATE | PURGE,
             ],
             [
                 'profiles_id' => $user_profile,

--- a/tests/Units/TagDestinationFieldTest.php
+++ b/tests/Units/TagDestinationFieldTest.php
@@ -50,6 +50,12 @@ final class TagDestinationFieldTest extends AbstractDestinationFieldTest
 {
     use FormTesterTrait;
 
+    public function setUp(): void
+    {
+        parent::setUp();
+        $this->login();
+    }
+
     public function testNoTags(): void
     {
         $form = $this->createAndGetFormWithMultipleTagQuestions();

--- a/tests/Units/TagItemTest.php
+++ b/tests/Units/TagItemTest.php
@@ -38,6 +38,8 @@ final class TagItemTest extends TagTestCase
 {
     public function testTagsFromTicket(): void
     {
+        $this->login();
+
         $tagID1 = $this->createTag('TicketTag1');
         $tagID2 = $this->createTag('TicketTag2');
 


### PR DESCRIPTION
## [2.14.7] - 2026-08-11

### Fixed

- Avoid a per-tag database lookup when rendering the tag column in item lists
- Ignore submitted tags that are not visible in the user entities when saving an item