### PR TITLE
2.12.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
-## [UNRELEASED]
+## [2.12.6] - 2026-09-11
 
 ### Fixed
 

--- a/inc/tag.class.php
+++ b/inc/tag.class.php
@@ -229,6 +229,9 @@ SQL;
             ],
         ]);
 
+        $profileRight = new ProfileRight();
+        $profileRight->deleteByCriteria(['name' => self::$rightname]);
+
         $migration = new Migration(PLUGIN_TAG_VERSION);
         $migration->dropTable(getTableForItemType(__CLASS__));
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -34,6 +34,11 @@
    </authors>
    <versions>
       <version>
+         <num>2.12.6</num>
+         <compatibility>~10.0.11</compatibility>
+         <download_url>https://github.com/pluginsGLPI/tag/releases/download/2.12.6/glpi-tag-2.12.6.tar.bz2</download_url>
+      </version>
+      <version>
          <num>2.12.5</num>
          <compatibility>~10.0.11</compatibility>
          <download_url>https://github.com/pluginsGLPI/tag/releases/download/2.12.5/glpi-tag-2.12.5.tar.bz2</download_url>

--- a/setup.php
+++ b/setup.php
@@ -30,7 +30,7 @@
 
 use Glpi\Plugin\Hooks;
 
-define('PLUGIN_TAG_VERSION', '2.12.5');
+define('PLUGIN_TAG_VERSION', '2.12.6');
 
 // Minimal GLPI version, inclusive
 define("PLUGIN_TAG_MIN_GLPI", "10.0.11");


### PR DESCRIPTION
## [2.12.6] - 2026-09-11

### Fixed

- Fix missing check for `Entity` tag visibility
- Prevent update of tags when the user has no update rights
- Prevent the tag field from appearing in the satisfaction survey.
- Ignore submitted tags that are not visible in the user entities when saving an item
